### PR TITLE
Groundwork for bot_admin_roles, plus configgenerator changes

### DIFF
--- a/cogs/config_commands.py
+++ b/cogs/config_commands.py
@@ -107,32 +107,37 @@ class ConfigCommands():
         :update_key: the key value to be updated in the passed in section
         :update_value: the value that matches the key
         """
-        try:
-            member_id = ctx.message.author.id
-            bot_admins = []
-
+        if update_section == 'ServerSettings':
+            return await self.bot.say("This is a protected section.")
+        else:
             try:
-                bot_admins_list = ConfigLoader().load_server_config_setting(ctx.message.server.id, 'ServerSettings', 'bot_admins')
-                for plugin in bot_admins_list.split():
-                    bot_admins.append(plugin)
-            except Exception as ex:
-                pass
+                member_id = ctx.message.author.id
 
-            if member_id == ctx.message.server.owner_id or \
-            int(member_id) == ConfigLoader().load_config_setting_int('BotSettings', 'owner_id') or \
-            str(member_id) in bot_admins:
-                filename = ctx.message.server.id
-                await self.update_config_file(
-                    filename,
-                    update_section,
-                    update_key,
-                    update_value,
-                    ctx.message
-                )
-            else:
-                return await self.bot.say("Only the server owner can configure different plugins.")
-        except (configparser.NoSectionError, configparser.NoOptionError) as config_error:
-            print("Error with updating the configuration file: \n{0}".format(config_error))
+                bot_admin_users = []
+                bot_admin_roles = []
+
+                try:
+                    bot_admins_user_list = ConfigLoader().load_server_config_setting(ctx.message.server.id, 'ServerSettings', 'bot_admin_users')
+                    for plugin in bot_admins_user_list.split():
+                        bot_admin_users.append(plugin)
+                except:
+                    pass
+
+                if member_id == ctx.message.server.owner_id or \
+                int(member_id) == ConfigLoader().load_config_setting_int('BotSettings', 'owner_id') or \
+                str(member_id) in bot_admin_users:
+                    filename = ctx.message.server.id
+                    await self.update_config_file(
+                        filename,
+                        update_section,
+                        update_key,
+                        update_value,
+                        ctx.message
+                    )
+                else:
+                    return await self.bot.say("Only the server owner can configure different plugins.")
+            except (configparser.NoSectionError, configparser.NoOptionError) as config_error:
+                print("Error with updating the configuration file: \n{0}".format(config_error))
 
     @commands.command(pass_context=True, no_pm=True, name='getconfig')
     @commands.cooldown(rate=1, per=1, type=commands.BucketType.user)

--- a/main.py
+++ b/main.py
@@ -99,7 +99,7 @@ async def on_message(message):
                 if message.author.id != CLIENT.user.id:
                     message_channel_id = ConfigLoader().load_server_int_setting(
                         message.server.id,
-                        'ServerSettings',
+                        'ConfigSettings',
                         'not_accepted_channel_id'
                     )
 

--- a/resources/configgenerator.py
+++ b/resources/configgenerator.py
@@ -1,6 +1,6 @@
 """
 configgenerator.py
-@author - Ryan Malacina (xNifty)
+@author - xNifty
 
 Functions: Generate the config file for a server
 @TODO: generate missing sections and key-values if missing
@@ -50,7 +50,17 @@ class ConfigGenerator():
         # ServerSettings config['testing'] = {'test': '45', 'test2': 'yes'}
         parser['ServerSettings'] = {
             'owner_id': owner_id,
-            'server_id': server_id,
+            'server_id': server_id
+        }
+
+        # BotAdmins
+        parser['BotAdmins'] = {
+            'bot_admin_users': 'NOT_SET',
+            'bot_admin_roles': 'NOT_SET' 
+        }
+
+        # ConfigSettings
+        parser['ConfigSettings'] = {
             'not_accepted_channel_id': 'NOT_SET'
         }
 

--- a/resources/general_resources.py
+++ b/resources/general_resources.py
@@ -34,7 +34,7 @@ class BotResources:
             try:
                 ConfigLoader().load_server_int_setting(
                     server_id,
-                    'ServerSettings',
+                    'ConfigSettings',
                     'not_accepted_channel_id'
                 )
                 return True


### PR DESCRIPTION
Change the code in configgenerator to reflect that not_accepted_channel_id was moved to ConfigSettings section, and that there is now a BotAdmins section. This also prevents changes to the ServerSettings section.